### PR TITLE
Forside-editor

### DIFF
--- a/forside.controller.php
+++ b/forside.controller.php
@@ -10,7 +10,7 @@ function UKMmonstring_forside_main() {
 
 	$monstring = new monstring_v2(get_option('pl_id'));
 	$TWIGdata = array('UKM_HOSTNAME' => UKM_HOSTNAME, 'monstringsLink' => $monstring->getLink());
-	$forside = get_page_by_title("Forside");
+	$forside = get_page_by_path('info');
 
 	$content = null;
 	if( null != $forside ) {
@@ -23,7 +23,8 @@ function UKMmonstring_forside_main() {
 		$content = $_POST['forside_editor'];
 		$new_content = array
 			(
-				'post_title' => "Forside",
+				'post_title' => "Forside", # Tittel på siden
+				'post_name' => 'info', # SLUG
 				'post_type' => 'page',
 				'post_content' =>  $_POST['forside_editor'],
 				'post_status' => 'publish'
@@ -47,21 +48,9 @@ function UKMmonstring_forside_main() {
 			}
 		}
 
-		// Dersom vi ikke har en nyhetsside, opprett den
-		$nyheter = opprettNyhetsside("Alle nyheter");
-		if( !is_numeric($nyheter) ) {
-			$TWIGdata['errors'][] = $nyheter;
-		}
-		// Oppdater innstillingene
-		if(is_numeric($front) && is_numeric($nyheter)) 
-			updateWPFrontPageSettings($front, $nyheter);
-		else {
-			$TWIGdata['errors'][] = "Kan ikke oppdatere forsideinnstillingene - feil med forside eller nyhetsside.";
-		}
-
 		// Last inn innholdet på nytt dersom lagring funka - for å laste inn bilder skikkelig.
 		if ( empty($TWIGdata['errors']) ) {
-			$forside = get_page_by_title("Forside");
+			$forside = get_page_by_path('info');
 			$content = $forside->post_content;
 		}
 	}
@@ -71,38 +60,6 @@ function UKMmonstring_forside_main() {
 	echo TWIG('forside_pre_editor.html.twig', $TWIGdata, dirname(__FILE__) );
 	wp_editor($content, 'forside_editor', $settings = array() );
 	echo TWIG('forside_post_editor.html.twig', $TWIGdata, dirname(__FILE__) );
-}
-
-// Oppretter nyhetsside dersom denne ikke allerede eksisterer
-// Returns the ID if successful, or a String with an error message if not.
-function opprettNyhetsside($name) {
-	$nyhetsside = get_page_by_title($name);
-	
-	// Hvis siden finnes er det OK.
-	if( null != $nyhetsside ) 
-		return $nyhetsside->ID;
-	
-	$new_content = array
-			(
-				'post_title' => $name,
-				'post_type' => 'page',
-				'post_content' =>  '',
-				'post_status' => 'publish'
-			);
-	$postID = wp_insert_post($new_content, true);
-	if( is_wp_error($postID) ){
-		$error = is_wp_error($postID) ? "Klarte ikke å lagre innhold som ny side! Feilmelding: ". $postID->get_error_message($code): "Klarte ikke å lagre innhold som ny side!";
-		return $error;
-	}
-	return $postID;
-}
-
-// Oppdaterer Wordpress-innstillingene for forside og nyhetsside.
-function updateWPFrontPageSettings($frontID, $postsID) {
-	update_option( 'page_on_front', $frontID );
-	update_option( 'show_on_front', 'page' );
-
-	update_option( 'page_for_posts', $postsID );
 }
 
 ?>

--- a/forside.controller.php
+++ b/forside.controller.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Oppretter forside-editor-siden. 
+ * Noted issues:
+ * - For å starte å skrive må man trykke på den ene tomme linjen, ikke det andre blanket området  - uten at det finnes en blinkende karet som hjelper deg med å se den.
+ * 
+ */
+function UKMmonstring_forside_main() {
+	UKMMonstring_script();
+
+	$monstring = new monstring_v2(get_option('pl_id'));
+	$TWIGdata = array('UKM_HOSTNAME' => UKM_HOSTNAME, 'monstringsLink' => $monstring->getLink());
+	$forside = get_page_by_title("Forside");
+
+	$content = null;
+	if( null != $forside ) {
+		$content = $forside->post_content;
+	}
+	
+	// Hvis brukeren har trykt lagre, og det ikke er en tom side.
+	if( 'POST' == $_SERVER['REQUEST_METHOD'] && !empty($_POST['forside_editor']) ) {
+		// Hvis vi har sendt inn data, vis det i editoren uavhengig om vi får til å lagre det eller ikke, sånn at folk  slipper å miste endringer.
+		$content = $_POST['forside_editor'];
+		$new_content = array
+			(
+				'post_title' => "Forside",
+				'post_type' => 'page',
+				'post_content' =>  $_POST['forside_editor'],
+				'post_status' => 'publish'
+			);
+		if( NULL == $forside ) {
+			// Ingen informasjon er lagret tidligere, opprett siden.
+			$front = wp_insert_post($new_content, true);
+			if( null == $front || is_wp_error($front) ){
+				$TWIGdata['errors'][] = is_wp_error($front) ? "Klarte ikke å lagre innhold som ny side! Feilmelding: ". $front->get_error_message($code): "Klarte ikke å lagre innhold som ny side!";
+			} else {
+				$TWIGdata['saved'] = "Opprettet ny forside! ID: ".$front;
+			}
+		} else {
+			// Eller oppdater den vi har fra før
+			$new_content['ID'] = $forside->ID;
+			$front = wp_update_post($new_content, true);
+			if( null == $front || is_wp_error($front) ) {
+				$TWIGdata['errors'][] = is_wp_error($front) ? "Klarte ikke å lagre oppdatert innhold! Feilmelding: ". $front->get_error_message($code): "Klarte ikke å oppdatere forsiden!";	
+			} else {
+				$TWIGdata['saved'] = "Oppdaterte forsiden din! ID: ".$front;
+			}
+		}
+
+		// Dersom vi ikke har en nyhetsside, opprett den
+		$nyheter = opprettNyhetsside("Alle nyheter");
+		if( !is_numeric($nyheter) ) {
+			$TWIGdata['errors'][] = $nyheter;
+		}
+		// Oppdater innstillingene
+		if(is_numeric($front) && is_numeric($nyheter)) 
+			updateWPFrontPageSettings($front, $nyheter);
+		else {
+			$TWIGdata['errors'][] = "Kan ikke oppdatere forsideinnstillingene - feil med forside eller nyhetsside.";
+		}
+
+		// Last inn innholdet på nytt dersom lagring funka - for å laste inn bilder skikkelig.
+		if ( empty($TWIGdata['errors']) ) {
+			$forside = get_page_by_title("Forside");
+			$content = $forside->post_content;
+		}
+	}
+
+	
+
+	echo TWIG('forside_pre_editor.html.twig', $TWIGdata, dirname(__FILE__) );
+	wp_editor($content, 'forside_editor', $settings = array() );
+	echo TWIG('forside_post_editor.html.twig', $TWIGdata, dirname(__FILE__) );
+}
+
+// Oppretter nyhetsside dersom denne ikke allerede eksisterer
+// Returns the ID if successful, or a String with an error message if not.
+function opprettNyhetsside($name) {
+	$nyhetsside = get_page_by_title($name);
+	
+	// Hvis siden finnes er det OK.
+	if( null != $nyhetsside ) 
+		return $nyhetsside->ID;
+	
+	$new_content = array
+			(
+				'post_title' => $name,
+				'post_type' => 'page',
+				'post_content' =>  '',
+				'post_status' => 'publish'
+			);
+	$postID = wp_insert_post($new_content, true);
+	if( is_wp_error($postID) ){
+		$error = is_wp_error($postID) ? "Klarte ikke å lagre innhold som ny side! Feilmelding: ". $postID->get_error_message($code): "Klarte ikke å lagre innhold som ny side!";
+		return $error;
+	}
+	return $postID;
+}
+
+// Oppdaterer Wordpress-innstillingene for forside og nyhetsside.
+function updateWPFrontPageSettings($frontID, $postsID) {
+	update_option( 'page_on_front', $frontID );
+	update_option( 'show_on_front', 'page' );
+
+	update_option( 'page_for_posts', $postsID );
+}
+
+?>

--- a/twig/forside_post_editor.html.twig
+++ b/twig/forside_post_editor.html.twig
@@ -1,0 +1,3 @@
+<p>&nbsp;</p>
+<button type="submit" class="btn btn-large btn-success">Lagre</button>
+</form>

--- a/twig/forside_pre_editor.html.twig
+++ b/twig/forside_pre_editor.html.twig
@@ -1,0 +1,12 @@
+<h1>Din forside</h1>
+<p class="lead">
+	Hva gjør UKM hos deg unikt?
+</p>
+<p>
+	For å gi tydeligere informasjon til deltakerne dine kan du nå redigere forsiden din selv. Denne siden kan brukes til å gi deltakerne dine mer konkret informasjon om ditt lokale UKM-miljø uten å bruke nyhetssaker - som gjerne begraves i arkivet.
+</p>
+<p>
+	Det du lager her finner du igjen på forsiden din: <a href="http:{{ monstringsLink }}" target="_blank">http:{{ monstringsLink }}</a>.
+</p>
+
+<form method="POST">

--- a/twig/forside_pre_editor.html.twig
+++ b/twig/forside_pre_editor.html.twig
@@ -1,4 +1,16 @@
 <h1>Din forside</h1>
+{% if saved is defined %}
+	<div class="alert alert-success">
+		{{ saved }}
+	</div>
+{% endif %}
+{% if errors is defined %}
+	{% for error in errors %}
+		<div class="alert alert-error">
+			{{ error }}
+		</div>
+	{% endfor %}
+{% endif %} 
 <p class="lead">
 	Hva gjør UKM hos deg unikt?
 </p>

--- a/ukmmonstring.php
+++ b/ukmmonstring.php
@@ -119,24 +119,10 @@ function UKMMonstring() {
 	}
 }
 
-/**
- * Oppretter forside-editor-siden. 
- * Noted issues:
- * - For å starte å skrive må man trykke på den ene tomme linjen, ikke det andre blanket området  - uten at det finnes en blinkende karet som hjelper deg med å se den.
- * 
- */
+## Move front-page stuff to separate file.
 function UKMmonstring_forside() {
-	UKMMonstring_script();
-	$option_name = 'forsidetekst_pl'.get_option('pl_id');
-	if( 'POST' == $_SERVER['REQUEST_METHOD'] ) {
-		$TWIG['saved'] = update_site_option($option_name, $_POST['forside_editor'] );
-	}
-
-	$monstring = new monstring_v2(get_option('pl_id'));
-	$TWIGdata = array('UKM_HOSTNAME' => UKM_HOSTNAME, 'monstringsLink' => $monstring->getLink());
-	echo TWIG('forside_pre_editor.html.twig', $TWIGdata, dirname(__FILE__) );
-	wp_editor( stripslashes(get_site_option($option_name)), 'forside_editor', $settings = array() );
-	echo TWIG('forside_post_editor.html.twig', $TWIGdata, dirname(__FILE__) );
+	require_once('forside.controller.php');
+	UKMmonstring_forside_main();
 }
 
 function UKMmonstring_videresending_info() {

--- a/ukmmonstring.php
+++ b/ukmmonstring.php
@@ -57,6 +57,19 @@ function UKMMonstring_menu() {
 	$name = get_option('site_type') == 'fylke' ? 'Min m&oslash;nstring' : 'M&oslash;nstring';
 	UKM_add_menu_page('monstring', $name, $name, 'editor', 'UKMMonstring', 'UKMMonstring', 'http://ico.ukm.no/hus-menu.png',1);
 	#add_submenu_page('UKMMonstring', 'Videresendingsinformasjon', 'Infotekst om videresending', 'editor', 'UKMvideresending_info', 'UKMmonstring_videresending_info');
+
+	// Legg til side for å redigere forsideinformasjonen.
+	if(get_option('site_type') == 'fylke' || get_option('site_type') == 'kommune') {
+		UKM_add_submenu_page(
+			'UKMMonstring', 
+			"Din forside", 
+			"Din forside", 
+			'editor', 
+			'UKMMonstring_forside', 
+			'UKMMonstring_forside'
+		);
+	}
+
 	if(get_option('site_type') == 'fylke') {
 		UKM_add_submenu_page(	'UKMMonstring', 
 								'Infotekst om videresending', 
@@ -66,6 +79,7 @@ function UKMMonstring_menu() {
 								'UKMmonstring_videresending_info'
 							);
 	}
+	
 	UKM_add_scripts_and_styles( 'UKMMonstring', 'UKMMonstring_script' );
 
 }
@@ -103,6 +117,26 @@ function UKMMonstring() {
 		
 		echo TWIG('monstring.twig.html', $infos, dirname(__FILE__));
 	}
+}
+
+/**
+ * Oppretter forside-editor-siden. 
+ * Noted issues:
+ * - For å starte å skrive må man trykke på den ene tomme linjen, ikke det andre blanket området  - uten at det finnes en blinkende karet som hjelper deg med å se den.
+ * 
+ */
+function UKMmonstring_forside() {
+	UKMMonstring_script();
+	$option_name = 'forsidetekst_pl'.get_option('pl_id');
+	if( 'POST' == $_SERVER['REQUEST_METHOD'] ) {
+		$TWIG['saved'] = update_site_option($option_name, $_POST['forside_editor'] );
+	}
+
+	$monstring = new monstring_v2(get_option('pl_id'));
+	$TWIGdata = array('UKM_HOSTNAME' => UKM_HOSTNAME, 'monstringsLink' => $monstring->getLink());
+	echo TWIG('forside_pre_editor.html.twig', $TWIGdata, dirname(__FILE__) );
+	wp_editor( stripslashes(get_site_option($option_name)), 'forside_editor', $settings = array() );
+	echo TWIG('forside_post_editor.html.twig', $TWIGdata, dirname(__FILE__) );
 }
 
 function UKMmonstring_videresending_info() {


### PR DESCRIPTION
- Lagt til forside-editor som egen side under Mønstring, med navn "Din forside".
- Lagrer dette som en egen page, med tittelen "Forside" og slug/path "info".
- Soft error - ved feil i lagringa vil det brukeren skrev bli sendt tilbake i tekstfeltet, slik at man ikke mister det. Feilmeldinger bootstrap-style.

**Teksten som møter brukerne på denne siden er foreløpig:**

Hva gjør UKM hos deg unikt?
-------
For å gi tydeligere informasjon til deltakerne dine kan du nå redigere forsiden din selv. Denne siden kan brukes til å gi deltakerne dine mer konkret informasjon om ditt lokale UKM-miljø uten å bruke nyhetssaker - som gjerne begraves i arkivet.

Det du lager her finner du igjen på forsiden din: **Link**
